### PR TITLE
Fix login redirect

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,7 @@ function PrivateRoute({ children }) {
   
   if (loading) return <div className="page">Loading...</div>;
   
-  return user ? children : <Navigate to="/login" />;
+  return user ? children : <Navigate to="/login" replace={true} />;
 }
 
 function NavBar() {
@@ -137,7 +137,7 @@ function AppRoutes() {
       )}
       <NavBar />
       <Routes>
-        <Route path="/login" element={user ? <Navigate to="/" /> : <Login />} />
+        <Route path="/login" element={user ? <Navigate to="/" replace={true} /> : <Login />} />
         <Route path="/email-sync" element={
           <PrivateRoute><EmailSync /></PrivateRoute>
         } />

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { login, register } from '../api';
+import { useAuth } from '../hooks/useAuth';
 
 function Login() {
   const navigate = useNavigate();
@@ -12,6 +13,7 @@ function Login() {
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const { checkAuth } = useAuth();
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -31,7 +33,6 @@ function Login() {
         const result = await login(formData.email, formData.password);
         console.log('Login result:', result);
         alert('Login successful! Redirecting...');
-        navigate('/');
       } else {
         if (!formData.name.trim()) {
           setError('Name is required');
@@ -41,8 +42,9 @@ function Login() {
         const result = await register(formData.email, formData.password, formData.name);
         console.log('Register result:', result);
         alert('Registration successful! Redirecting...');
-        navigate('/');
       }
+      await checkAuth();
+      navigate('/');
     } catch (err) {
       console.error('Auth error:', err);
       alert('Error: ' + (err.message || 'An error occurred'));


### PR DESCRIPTION
Fixes PN-13 in Jira taskboard.

When logging in or registering, it would say "redirecting," but not successfully redirect to the dashboard. This fixes it by refreshing the user authentication so the system is updated with the fact that the user is now logged in.

I also went ahead and made sure that redirects update the browser history where it makes sense by adding `replace={true}` to redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message display and loading state handling during login and registration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->