### PR TITLE
Fix syntax errors from conflicting changes by different people

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -298,7 +298,9 @@ export async function deleteGoogleCalendarEvent(eventId) {
 }
 
 export async function exportTaskToGoogleCalendar(taskId) {
-  return fetchApi(`/google-calendar/export-task/${taskId}`, { method: 'POST' });
+  return fetchApi(`/google-calendar/export-task/${taskId}`, {method: 'POST'});
+}
+
 export const TaskListSortMethod = Object.freeze({
   DATE: {
     name: "date",

--- a/frontend/src/hooks/useLanguage.js
+++ b/frontend/src/hooks/useLanguage.js
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { en, es } from '../translations';
 
-const translations = { en, es };
+/*const translations = { en, es };*/ // TODO: Add this back in if we end up separating the modules
 const translations = {
   en: {
     dashboard: 'Dashboard', tasks: 'Tasks', weekly: 'Weekly', monthly: 'Monthly', today: 'Today',
@@ -110,7 +110,7 @@ const translations = {
     densityComfortable: 'Comfortable',
     densityCompact: 'Compact',
     tasksPageSubtitle: 'Search, filter, and manage your full task library.',
-    taskLibrary: 'Task library',
+    taskLibrary: 'Task library', groupBy: 'Group by'
   },
   es: {
     dashboard: 'Panel', tasks: 'Tareas', weekly: 'Semanal', monthly: 'Mensual', today: 'Hoy',
@@ -1249,7 +1249,6 @@ export function LanguageProvider({ children }) {
     const langTranslations = translations[language] || translations.en;
     return langTranslations[key] || translations.en[key] || key;
   };
-  const t = (key) => translations[language]?.[key] || translations.en[key] || null;
 
   return (
     <LanguageContext.Provider value={{ language, setLanguage, t, languages, dir }}>


### PR DESCRIPTION
Closed function definition that was left open and removed duplicate definitions in `useLanguage.js`.

In `useLanguage.js` it looks like @mainuddinMains was trying to refactor the translations into separate files, but only did two languages (English and Spanish). So I opted to keep the translations together in one file for now until the separation is complete, if that's something @mainuddinMains still wants to implement.

For the duplicate `t` definition in `useLanguage.js`, I removed the one that falls back on `null`. I had done that because `groupBy` didn't have a translation, so I just added the English one instead of falling back on `null`.

The project now runs without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Group by" option to the interface.

* **Refactor**
  * Improved translation handling with enhanced fallback behavior for more consistent localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->