### PR TITLE
Drag-and-Drop Calendar

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1489,7 +1489,7 @@ nav a:hover {
 }
 
 .monthly-calendar {
-  max-width: 1200px;
+  max-width: 1400px;
 }
 
 .month-navigation {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -877,6 +877,32 @@ nav a:hover {
   background: #fafafa;
 }
 
+.focus-panel-inner-list .task-item[draggable="true"] {
+  cursor: grab;
+}
+
+.focus-panel-inner-list .task-item[draggable="true"]:active {
+  cursor: grabbing;
+}
+
+.unschedule-drop-zone {
+  border: 2px dashed #d1d5db;
+  background: #f9fafb;
+  color: #6b7280;
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.8rem;
+  text-align: center;
+  margin-bottom: 0.75rem;
+  transition: all 0.2s ease;
+}
+
+.unschedule-drop-zone.drag-over {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
 .tasks-section-heading {
   display: flex;
   flex-wrap: wrap;
@@ -2302,6 +2328,18 @@ nav a:hover {
 
 [data-theme="dark"] .task-item.overdue {
   background: rgba(220, 38, 38, 0.1);
+}
+
+[data-theme="dark"] .unschedule-drop-zone {
+  background: var(--bg-secondary);
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+[data-theme="dark"] .unschedule-drop-zone.drag-over {
+  background: rgba(220, 38, 38, 0.16);
+  border-color: #f87171;
+  color: #fca5a5;
 }
 
 [data-theme="dark"] .task-title {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1231,6 +1231,30 @@ nav a:hover {
   max-width: 1400px;
 }
 
+.calendar-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.calendar-main-column {
+  min-width: 0;
+}
+
+.calendar-side-column {
+  min-width: 0;
+}
+
+.calendar-side-column .focus-panel {
+  position: sticky;
+  top: 1rem;
+}
+
+.calendar-side-column .focus-panel-inner-list {
+  max-height: 520px;
+}
+
 .calendar-header {
   display: flex;
   justify-content: space-between;
@@ -1411,6 +1435,14 @@ nav a:hover {
 }
 
 @media (max-width: 1024px) {
+  .calendar-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-side-column .focus-panel {
+    position: static;
+  }
+
   .calendar-grid {
     grid-template-columns: repeat(4, 1fr);
   }

--- a/frontend/src/components/MiniTaskList.jsx
+++ b/frontend/src/components/MiniTaskList.jsx
@@ -1,10 +1,84 @@
-import React, { useState } from 'react';
+import React, { useMemo } from 'react';
+import TaskItem from './TaskItem';
+import { useLanguage } from '../hooks/useLanguage';
 
-function MiniTaskList({ tasks }) {
-  return (
-    <div className="mini-task-list">
-    </div>
-  )
+const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 };
+const NOOP = () => {};
+
+function rankFocusTasks(tasks, limit = 5) {
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const todayEnd = new Date(todayStart);
+  todayEnd.setHours(23, 59, 59, 999);
+
+  const openTasks = tasks.filter((task) => !task.is_completed);
+
+  return [...openTasks]
+    .sort((a, b) => {
+      const dueA = a.due_date ? new Date(a.due_date) : null;
+      const dueB = b.due_date ? new Date(b.due_date) : null;
+      const overdueA = dueA && dueA < now;
+      const overdueB = dueB && dueB < now;
+      if (overdueA !== overdueB) return overdueA ? -1 : 1;
+
+      const todayA = dueA && dueA >= todayStart && dueA <= todayEnd && !overdueA;
+      const todayB = dueB && dueB >= todayStart && dueB <= todayEnd && !overdueB;
+      if (todayA !== todayB) return todayA ? -1 : 1;
+
+      if (dueA && dueB) return dueA - dueB;
+      if (dueA) return -1;
+      if (dueB) return 1;
+
+      const priorityA = PRIORITY_ORDER[a.priority] ?? 1;
+      const priorityB = PRIORITY_ORDER[b.priority] ?? 1;
+      return priorityA - priorityB;
+    })
+    .slice(0, limit);
 }
 
-export default MiniTaskList
+function MiniTaskList({
+  tasks = [],
+  onToggle,
+  onEdit,
+  onDelete,
+  limit = 5,
+  prioritize = true,
+  readOnly = false,
+  density = 'compact',
+  emptyMessageKey = 'focusEmpty',
+  className = '',
+  emptyClassName = '',
+}) {
+  const { t } = useLanguage();
+
+  const visibleTasks = useMemo(() => {
+    if (!Array.isArray(tasks) || tasks.length === 0) return [];
+    if (!prioritize) return tasks.slice(0, limit);
+    return rankFocusTasks(tasks, limit);
+  }, [tasks, prioritize, limit]);
+
+  const listClassName = `task-list ${density === 'compact' ? 'task-list--compact' : ''} ${className}`.trim();
+  const emptyStateClassName = `empty-state ${emptyClassName}`.trim();
+
+  return (
+    <div className={listClassName}>
+      {visibleTasks.length === 0 ? (
+        <div className={emptyStateClassName}>{t(emptyMessageKey)}</div>
+      ) : (
+        visibleTasks.map((task) => (
+          <TaskItem
+            key={task.id}
+            task={task}
+            onToggle={onToggle || NOOP}
+            onEdit={onEdit || NOOP}
+            onDelete={onDelete || NOOP}
+            density={density}
+            readOnly={readOnly}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+export default MiniTaskList;

--- a/frontend/src/components/MiniTaskList.jsx
+++ b/frontend/src/components/MiniTaskList.jsx
@@ -48,6 +48,9 @@ function MiniTaskList({
   emptyMessageKey = 'focusEmpty',
   className = '',
   emptyClassName = '',
+  draggable = false,
+  onTaskDragStart,
+  onTaskDragEnd,
 }) {
   const { t } = useLanguage();
 
@@ -74,6 +77,9 @@ function MiniTaskList({
             onDelete={onDelete || NOOP}
             density={density}
             readOnly={readOnly}
+            draggable={draggable}
+            onDragStart={onTaskDragStart}
+            onDragEnd={onTaskDragEnd}
           />
         ))
       )}

--- a/frontend/src/components/MiniTaskList.jsx
+++ b/frontend/src/components/MiniTaskList.jsx
@@ -1,0 +1,10 @@
+import React, { useState } from 'react';
+
+function MiniTaskList({ tasks }) {
+  return (
+    <div className="mini-task-list">
+    </div>
+  )
+}
+
+export default MiniTaskList

--- a/frontend/src/components/MiniTaskList.jsx
+++ b/frontend/src/components/MiniTaskList.jsx
@@ -5,7 +5,7 @@ import { useLanguage } from '../hooks/useLanguage';
 const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 };
 const NOOP = () => {};
 
-function rankFocusTasks(tasks, limit = 5) {
+function rankFocusTasks(tasks, limit) {
   const now = new Date();
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const todayEnd = new Date(todayStart);
@@ -41,7 +41,7 @@ function MiniTaskList({
   onToggle,
   onEdit,
   onDelete,
-  limit = 5,
+  limit,
   prioritize = true,
   readOnly = false,
   density = 'compact',

--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -8,6 +8,9 @@ function TaskItem({
   onDelete = () => {},
   density = 'comfortable',
   readOnly = false,
+  draggable = false,
+  onDragStart,
+  onDragEnd,
 }) {
   const { t } = useLanguage();
   
@@ -42,6 +45,9 @@ function TaskItem({
       className={`task-item ${task.is_completed ? 'completed' : ''} ${isOverdue ? 'overdue' : ''} ${
         density === 'compact' ? 'task-item--compact' : ''
       }`}
+      draggable={draggable && !task.is_completed}
+      onDragStart={draggable ? (e) => onDragStart?.(e, task) : undefined}
+      onDragEnd={draggable ? onDragEnd : undefined}
     >
       {!readOnly && (
         <div className="task-checkbox">

--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { useLanguage } from '../hooks/useLanguage';
 
-function TaskItem({ task, onToggle, onEdit, onDelete, density = 'comfortable' }) {
+function TaskItem({
+  task,
+  onToggle = () => {},
+  onEdit = () => {},
+  onDelete = () => {},
+  density = 'comfortable',
+  readOnly = false,
+}) {
   const { t } = useLanguage();
   
   const formatDate = (dateString) => {
@@ -36,13 +43,15 @@ function TaskItem({ task, onToggle, onEdit, onDelete, density = 'comfortable' })
         density === 'compact' ? 'task-item--compact' : ''
       }`}
     >
-      <div className="task-checkbox">
-        <input
-          type="checkbox"
-          checked={task.is_completed}
-          onChange={() => onToggle(task.id, !task.is_completed)}
-        />
-      </div>
+      {!readOnly && (
+        <div className="task-checkbox">
+          <input
+            type="checkbox"
+            checked={task.is_completed}
+            onChange={() => onToggle(task.id, !task.is_completed)}
+          />
+        </div>
+      )}
 
       <div className="task-content">
         <div className="task-header">
@@ -73,14 +82,16 @@ function TaskItem({ task, onToggle, onEdit, onDelete, density = 'comfortable' })
         </div>
       </div>
 
-      <div className="task-actions">
-        <button onClick={() => onEdit(task)} className="btn-icon" title={t('edit')}>
-          ✏️
-        </button>
-        <button onClick={() => onDelete(task.id)} className="btn-icon" title={t('delete')}>
-          🗑️
-        </button>
-      </div>
+      {!readOnly && (
+        <div className="task-actions">
+          <button onClick={() => onEdit(task)} className="btn-icon" title={t('edit')}>
+            ✏️
+          </button>
+          <button onClick={() => onDelete(task.id)} className="btn-icon" title={t('delete')}>
+            🗑️
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/FocusTasks.jsx
+++ b/frontend/src/components/dashboard/FocusTasks.jsx
@@ -1,42 +1,9 @@
-import React, { useMemo } from 'react';
-import TaskItem from '../TaskItem';
+import React from 'react';
+import MiniTaskList from '../MiniTaskList';
 import { useLanguage } from '../../hooks/useLanguage';
-
-const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 };
-
-function rankFocusTasks(tasks, limit = 5) {
-  const now = new Date();
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const todayEnd = new Date(todayStart);
-  todayEnd.setHours(23, 59, 59, 999);
-
-  const open = tasks.filter((t) => !t.is_completed);
-
-  return [...open]
-    .sort((a, b) => {
-      const da = a.due_date ? new Date(a.due_date) : null;
-      const db = b.due_date ? new Date(b.due_date) : null;
-      const aOver = da && da < now;
-      const bOver = db && db < now;
-      if (aOver !== bOver) return aOver ? -1 : 1;
-      const aToday =
-        da && da >= todayStart && da <= todayEnd && !aOver;
-      const bToday =
-        db && db >= todayStart && db <= todayEnd && !bOver;
-      if (aToday !== bToday) return aToday ? -1 : 1;
-      if (da && db) return da - db;
-      if (da) return -1;
-      if (db) return 1;
-      const pa = PRIORITY_ORDER[a.priority] ?? 1;
-      const pb = PRIORITY_ORDER[b.priority] ?? 1;
-      return pa - pb;
-    })
-    .slice(0, limit);
-}
 
 function FocusTasks({ tasks = [], onToggle, onEdit, onDelete, limit = 5 }) {
   const { t } = useLanguage();
-  const focusList = useMemo(() => rankFocusTasks(tasks, limit), [tasks, limit]);
 
   return (
     <section className="focus-panel" aria-labelledby="focus-panel-title">
@@ -44,24 +11,20 @@ function FocusTasks({ tasks = [], onToggle, onEdit, onDelete, limit = 5 }) {
         {t('focusNextTasks')}
       </h2>
       <p className="focus-panel-hint">{t('focusNextTasksHint')}</p>
-      {focusList.length === 0 ? (
-        <div className="focus-panel-empty empty-state">{t('focusEmpty')}</div>
-      ) : (
-        <div className="focus-panel-list">
-          <div className="task-list focus-panel-inner-list">
-            {focusList.map((task) => (
-              <TaskItem
-                key={task.id}
-                task={task}
-                onToggle={onToggle}
-                onEdit={onEdit}
-                onDelete={onDelete}
-                density="compact"
-              />
-            ))}
-          </div>
-        </div>
-      )}
+      <div className="focus-panel-list">
+        <MiniTaskList
+          tasks={tasks}
+          onToggle={onToggle}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          limit={limit}
+          prioritize
+          density="compact"
+          className="focus-panel-inner-list"
+          emptyMessageKey="focusEmpty"
+          emptyClassName="focus-panel-empty"
+        />
+      </div>
     </section>
   );
 }

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -5,3 +5,4 @@ export { default as NotificationBell } from './NotificationBell';
 export { default as AIAssistant } from './AIAssistant';
 export { default as FocusTimer } from './FocusTimer';
 export { default as AISettings } from './AISettings';
+export { default as MiniTaskList } from './MiniTaskList';

--- a/frontend/src/pages/MonthlyCalendar.jsx
+++ b/frontend/src/pages/MonthlyCalendar.jsx
@@ -159,60 +159,81 @@ function MonthlyCalendar() {
         </div>
       </div>
 
-      <MiniTaskList tasks={tasks}/>
+      <div className="calendar-layout">
+        <div className="calendar-main-column">
+          {message && <div className="success-message">{message}</div>}
 
-      {message && <div className="success-message">{message}</div>}
+          <div className="month-info">
+            <h2>{formatMonthYear()}</h2>
+          </div>
 
-      <div className="month-info">
-        <h2>{formatMonthYear()}</h2>
-      </div>
+          <div className="month-grid">
+            {weekDays.map(day => (
+              <div key={day} className="month-weekday">{day}</div>
+            ))}
 
-      <div className="month-grid">
-        {weekDays.map(day => (
-          <div key={day} className="month-weekday">{day}</div>
-        ))}
-        
-        {getMonthDays().map((dayInfo, index) => {
-          const dayTasks = getTasksForDay(dayInfo.date);
-          const isCurrentDay = isToday(dayInfo.date);
-          
-          return (
-            <div
-              key={index}
-              className={`month-day ${!dayInfo.isCurrentMonth ? 'other-month' : ''} ${isCurrentDay ? 'today' : ''} ${dragOverDay?.toDateString() === dayInfo.date.toDateString() ? 'drag-over' : ''}`}
-              onDragOver={(e) => handleDragOver(e, dayInfo.date)}
-              onDragLeave={handleDragLeave}
-              onDrop={(e) => handleDrop(e, dayInfo.date)}
-            >
-              <div className="day-header">
-                <span className="day-number">{dayInfo.date.getDate()}</span>
-                {dayTasks.length > 0 && (
-                  <span className="task-count">{dayTasks.length}</span>
-                )}
-              </div>
-              
-              <div className="day-tasks">
-                {dayTasks.slice(0, 3).map(task => (
-                  <div
-                    key={task.id}
-                    className={`month-task ${task.is_completed ? 'completed' : ''} ${draggedTask?.task.id === task.id ? 'dragging' : ''}`}
-                    style={{ borderLeftColor: task.course_color || '#4a90a4' }}
-                    draggable={!task.is_completed}
-                    onDragStart={(e) => handleDragStart(e, task, dayInfo.date)}
-                    onDragEnd={handleDragEnd}
-                    title={task.title}
-                  >
-                    <span className="task-dot">•</span>
-                    <span className="task-name">{task.title}</span>
+            {getMonthDays().map((dayInfo, index) => {
+              const dayTasks = getTasksForDay(dayInfo.date);
+              const isCurrentDay = isToday(dayInfo.date);
+
+              return (
+                <div
+                  key={index}
+                  className={`month-day ${!dayInfo.isCurrentMonth ? 'other-month' : ''} ${isCurrentDay ? 'today' : ''} ${dragOverDay?.toDateString() === dayInfo.date.toDateString() ? 'drag-over' : ''}`}
+                  onDragOver={(e) => handleDragOver(e, dayInfo.date)}
+                  onDragLeave={handleDragLeave}
+                  onDrop={(e) => handleDrop(e, dayInfo.date)}
+                >
+                  <div className="day-header">
+                    <span className="day-number">{dayInfo.date.getDate()}</span>
+                    {dayTasks.length > 0 && (
+                      <span className="task-count">{dayTasks.length}</span>
+                    )}
                   </div>
-                ))}
-                {dayTasks.length > 3 && (
-                  <div className="more-tasks">+{dayTasks.length - 3} more</div>
-                )}
-              </div>
-            </div>
-          );
-        })}
+
+                  <div className="day-tasks">
+                    {dayTasks.slice(0, 3).map(task => (
+                      <div
+                        key={task.id}
+                        className={`month-task ${task.is_completed ? 'completed' : ''} ${draggedTask?.task.id === task.id ? 'dragging' : ''}`}
+                        style={{ borderLeftColor: task.course_color || '#4a90a4' }}
+                        draggable={!task.is_completed}
+                        onDragStart={(e) => handleDragStart(e, task, dayInfo.date)}
+                        onDragEnd={handleDragEnd}
+                        title={task.title}
+                      >
+                        <span className="task-dot">•</span>
+                        <span className="task-name">{task.title}</span>
+                      </div>
+                    ))}
+                    {dayTasks.length > 3 && (
+                      <div className="more-tasks">+{dayTasks.length - 3} more</div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <aside className="calendar-side-column">
+          <section className="focus-panel" aria-labelledby="monthly-side-tasks-title">
+            <h2 id="monthly-side-tasks-title" className="focus-panel-title">
+              Top Tasks
+            </h2>
+            <p className="focus-panel-hint">Drag these tasks over to a day to set a due date.</p>
+            <MiniTaskList
+              tasks={tasks}
+              limit={5}
+              prioritize
+              readOnly
+              density="compact"
+              emptyMessageKey="noTasks"
+              className="focus-panel-inner-list"
+              emptyClassName="focus-panel-empty"
+            />
+          </section>
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/pages/MonthlyCalendar.jsx
+++ b/frontend/src/pages/MonthlyCalendar.jsx
@@ -79,14 +79,6 @@ function MonthlyCalendar() {
     return currentDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
   };
 
-  const getPriorityClass = (priority) => {
-    switch (priority) {
-      case 'high': return 'priority-high';
-      case 'low': return 'priority-low';
-      default: return 'priority-medium';
-    }
-  };
-
   const handleDragStart = (e, task, date) => {
     const fallbackDate = date instanceof Date ? date : null;
     setDraggedTask({
@@ -276,7 +268,6 @@ function MonthlyCalendar() {
             </div>
             <MiniTaskList
               tasks={tasks.filter(task => !task.due_date)}
-              limit={5}
               prioritize
               readOnly
               density="compact"

--- a/frontend/src/pages/MonthlyCalendar.jsx
+++ b/frontend/src/pages/MonthlyCalendar.jsx
@@ -132,7 +132,7 @@ function MonthlyCalendar() {
   const handleUnscheduleDragOver = (e) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
-    setIsUnscheduleDragOver(true);
+    setIsUnscheduleDragOver((prev) => (prev ? prev : true));
   };
 
   const handleUnscheduleDragLeave = () => {

--- a/frontend/src/pages/MonthlyCalendar.jsx
+++ b/frontend/src/pages/MonthlyCalendar.jsx
@@ -10,6 +10,7 @@ function MonthlyCalendar() {
   const [loading, setLoading] = useState(true);
   const [draggedTask, setDraggedTask] = useState(null);
   const [dragOverDay, setDragOverDay] = useState(null);
+  const [isUnscheduleDragOver, setIsUnscheduleDragOver] = useState(false);
   const [message, setMessage] = useState('');
 
   useEffect(() => {
@@ -87,7 +88,11 @@ function MonthlyCalendar() {
   };
 
   const handleDragStart = (e, task, date) => {
-    setDraggedTask({ task, originalDate: date });
+    const fallbackDate = date instanceof Date ? date : null;
+    setDraggedTask({
+      task,
+      originalDueDate: task.due_date || (fallbackDate ? fallbackDate.toISOString() : null),
+    });
     e.dataTransfer.effectAllowed = 'move';
   };
 
@@ -103,14 +108,19 @@ function MonthlyCalendar() {
   const handleDrop = async (e, targetDate) => {
     e.preventDefault();
     setDragOverDay(null);
+    setIsUnscheduleDragOver(false);
     
     if (!draggedTask) return;
     
-    const originalDate = new Date(draggedTask.originalDate);
+    const originalDate = draggedTask.originalDueDate
+      ? new Date(draggedTask.originalDueDate)
+      : null;
     const newDate = new Date(targetDate);
-    newDate.setHours(originalDate.getHours(), originalDate.getMinutes(), 0, 0);
+    const hours = originalDate ? originalDate.getHours() : 9;
+    const minutes = originalDate ? originalDate.getMinutes() : 0;
+    newDate.setHours(hours, minutes, 0, 0);
     
-    if (newDate.toDateString() === originalDate.toDateString()) {
+    if (originalDate && newDate.toDateString() === originalDate.toDateString()) {
       setDraggedTask(null);
       return;
     }
@@ -127,9 +137,43 @@ function MonthlyCalendar() {
     setDraggedTask(null);
   };
 
+  const handleUnscheduleDragOver = (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setIsUnscheduleDragOver(true);
+  };
+
+  const handleUnscheduleDragLeave = () => {
+    setIsUnscheduleDragOver(false);
+  };
+
+  const handleUnscheduleDrop = async (e) => {
+    e.preventDefault();
+    setDragOverDay(null);
+    setIsUnscheduleDragOver(false);
+
+    if (!draggedTask) return;
+    if (!draggedTask.task?.due_date) {
+      setDraggedTask(null);
+      return;
+    }
+
+    try {
+      await updateTask(draggedTask.task.id, { due_date: null });
+      setMessage('Task unscheduled');
+      setTimeout(() => setMessage(''), 3000);
+      fetchTasks();
+    } catch (err) {
+      console.error('Failed to unschedule task:', err);
+    }
+
+    setDraggedTask(null);
+  };
+
   const handleDragEnd = () => {
     setDraggedTask(null);
     setDragOverDay(null);
+    setIsUnscheduleDragOver(false);
   };
 
   const isToday = (date) => {
@@ -219,11 +263,19 @@ function MonthlyCalendar() {
         <aside className="calendar-side-column">
           <section className="focus-panel" aria-labelledby="monthly-side-tasks-title">
             <h2 id="monthly-side-tasks-title" className="focus-panel-title">
-              Top Tasks
+              Unscheduled Tasks
             </h2>
             <p className="focus-panel-hint">Drag these tasks over to a day to set a due date.</p>
+            <div
+              className={`unschedule-drop-zone ${isUnscheduleDragOver ? 'drag-over' : ''}`}
+              onDragOver={handleUnscheduleDragOver}
+              onDragLeave={handleUnscheduleDragLeave}
+              onDrop={handleUnscheduleDrop}
+            >
+              Drag here to remove a due date
+            </div>
             <MiniTaskList
-              tasks={tasks}
+              tasks={tasks.filter(task => !task.due_date)}
               limit={5}
               prioritize
               readOnly
@@ -231,6 +283,9 @@ function MonthlyCalendar() {
               emptyMessageKey="noTasks"
               className="focus-panel-inner-list"
               emptyClassName="focus-panel-empty"
+              draggable
+              onTaskDragStart={handleDragStart}
+              onTaskDragEnd={handleDragEnd}
             />
           </section>
         </aside>

--- a/frontend/src/pages/MonthlyCalendar.jsx
+++ b/frontend/src/pages/MonthlyCalendar.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../hooks/useLanguage';
 import { getTasks, updateTask } from '../api';
+import { MiniTaskList } from "../components";
 
 function MonthlyCalendar() {
   const { t } = useLanguage();
@@ -157,6 +158,8 @@ function MonthlyCalendar() {
           </button>
         </div>
       </div>
+
+      <MiniTaskList tasks={tasks}/>
 
       {message && <div className="success-message">{message}</div>}
 

--- a/frontend/src/pages/WeeklyCalendar.jsx
+++ b/frontend/src/pages/WeeklyCalendar.jsx
@@ -154,80 +154,101 @@ function WeeklyCalendar() {
         </div>
       </div>
 
-      <MiniTaskList tasks={Object.values(tasksByDay).flat()} />
-
-      <div className="week-info">
-        <h2>{formatWeekRange()}</h2>
-        <div className="week-stats">
-          <span className="stat">{getTaskCount()} {t('tasks')}</span>
-          <span className="stat">{Math.round(getTotalDuration() / 60)}{t('hours')}</span>
-        </div>
-      </div>
-
-      {message && (
-        <div className="success-message">{message}</div>
-      )}
-
-      <div className="calendar-grid">
-        {weekDays.map((day, index) => {
-          const dayTasks = tasksByDay[day.toDateString()] || [];
-          const isToday = day.toDateString() === new Date().toDateString();
-          const totalMinutes = dayTasks.reduce((sum, t) => sum + (t.duration || 0), 0);
-
-          return (
-            <div 
-              key={index} 
-              className={`calendar-day ${isToday ? 'today' : ''} ${dragOverDay?.toDateString() === day.toDateString() ? 'drag-over' : ''}`}
-              onDragOver={(e) => handleDragOver(e, day)}
-              onDragLeave={handleDragLeave}
-              onDrop={(e) => handleDrop(e, day)}
-            >
-              {formatDayHeader(day)}
-              
-              <div className="day-workload">
-                {totalMinutes > 0 && (
-                  <span className="workload-badge">
-                    {totalMinutes >= 60 
-                      ? `${Math.round(totalMinutes / 60)}h ${totalMinutes % 60}m`
-                      : `${totalMinutes}m`
-                    }
-                  </span>
-                )}
-              </div>
-
-              <div className="day-tasks">
-                {dayTasks.length === 0 ? (
-                  <div className="no-tasks">{t('noTasks')}</div>
-                ) : (
-                  dayTasks.map(task => (
-                    <div
-                      key={task.id}
-                      className={`calendar-task ${task.is_completed ? 'completed' : ''} ${draggedTask?.task.id === task.id ? 'dragging' : ''}`}
-                      style={{ borderLeftColor: task.course_color || '#4a90a4' }}
-                      draggable={!task.is_completed}
-                      onDragStart={(e) => handleDragStart(e, task, day)}
-                      onDragEnd={handleDragEnd}
-                    >
-                      <div className="task-time">{formatTime(task.due_date)}</div>
-                      <div className="task-title">{task.title}</div>
-                      <div className="task-badges">
-                        <span className={`task-priority ${getPriorityClass(task.priority)}`}>
-                          {task.priority}
-                        </span>
-                        {task.duration && (
-                          <span className="task-duration">{task.duration}m</span>
-                        )}
-                      </div>
-                      {task.course_name && (
-                        <div className="task-course">{task.course_name}</div>
-                      )}
-                    </div>
-                  ))
-                )}
-              </div>
+      <div className="calendar-layout">
+        <div className="calendar-main-column">
+          <div className="week-info">
+            <h2>{formatWeekRange()}</h2>
+            <div className="week-stats">
+              <span className="stat">{getTaskCount()} {t('tasks')}</span>
+              <span className="stat">{Math.round(getTotalDuration() / 60)}{t('hours')}</span>
             </div>
-          );
-        })}
+          </div>
+
+          {message && (
+            <div className="success-message">{message}</div>
+          )}
+
+          <div className="calendar-grid">
+            {weekDays.map((day, index) => {
+              const dayTasks = tasksByDay[day.toDateString()] || [];
+              const isToday = day.toDateString() === new Date().toDateString();
+              const totalMinutes = dayTasks.reduce((sum, t) => sum + (t.duration || 0), 0);
+
+              return (
+                <div
+                  key={index}
+                  className={`calendar-day ${isToday ? 'today' : ''} ${dragOverDay?.toDateString() === day.toDateString() ? 'drag-over' : ''}`}
+                  onDragOver={(e) => handleDragOver(e, day)}
+                  onDragLeave={handleDragLeave}
+                  onDrop={(e) => handleDrop(e, day)}
+                >
+                  {formatDayHeader(day)}
+
+                  <div className="day-workload">
+                    {totalMinutes > 0 && (
+                      <span className="workload-badge">
+                        {totalMinutes >= 60
+                          ? `${Math.round(totalMinutes / 60)}h ${totalMinutes % 60}m`
+                          : `${totalMinutes}m`
+                        }
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="day-tasks">
+                    {dayTasks.length === 0 ? (
+                      <div className="no-tasks">{t('noTasks')}</div>
+                    ) : (
+                      dayTasks.map(task => (
+                        <div
+                          key={task.id}
+                          className={`calendar-task ${task.is_completed ? 'completed' : ''} ${draggedTask?.task.id === task.id ? 'dragging' : ''}`}
+                          style={{ borderLeftColor: task.course_color || '#4a90a4' }}
+                          draggable={!task.is_completed}
+                          onDragStart={(e) => handleDragStart(e, task, day)}
+                          onDragEnd={handleDragEnd}
+                        >
+                          <div className="task-time">{formatTime(task.due_date)}</div>
+                          <div className="task-title">{task.title}</div>
+                          <div className="task-badges">
+                            <span className={`task-priority ${getPriorityClass(task.priority)}`}>
+                              {task.priority}
+                            </span>
+                            {task.duration && (
+                              <span className="task-duration">{task.duration}m</span>
+                            )}
+                          </div>
+                          {task.course_name && (
+                            <div className="task-course">{task.course_name}</div>
+                          )}
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <aside className="calendar-side-column">
+          <section className="focus-panel" aria-labelledby="weekly-side-tasks-title">
+            <h2 id="weekly-side-tasks-title" className="focus-panel-title">
+              Top Tasks
+            </h2>
+            <p className="focus-panel-hint">Drag these tasks over to a day to set a due date.</p>
+            <MiniTaskList
+              tasks={Object.values(tasksByDay).flat()}
+              limit={5}
+              prioritize
+              readOnly
+              density="compact"
+              emptyMessageKey="noTasks"
+              className="focus-panel-inner-list"
+              emptyClassName="focus-panel-empty"
+            />
+          </section>
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/pages/WeeklyCalendar.jsx
+++ b/frontend/src/pages/WeeklyCalendar.jsx
@@ -7,6 +7,7 @@ import { MiniTaskList } from "../components";
 function WeeklyCalendar() {
   const { t } = useLanguage();
   const {
+    tasks,
     tasksByDay,
     weekDays,
     loading,
@@ -14,16 +15,16 @@ function WeeklyCalendar() {
     goToPreviousWeek,
     goToNextWeek,
     goToCurrentWeek,
-    currentWeekStart,
     refresh
   } = useWeeklyTasks();
   
   const [draggedTask, setDraggedTask] = useState(null);
   const [dragOverDay, setDragOverDay] = useState(null);
+  const [isUnscheduleDragOver, setIsUnscheduleDragOver] = useState(false);
   const [message, setMessage] = useState('');
 
-  const handleDragStart = (e, task, day) => {
-    setDraggedTask({ task, originalDay: day });
+  const handleDragStart = (e, task) => {
+    setDraggedTask({ task, originalDueDate: task.due_date || null });
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', JSON.stringify({ taskId: task.id }));
   };
@@ -41,17 +42,20 @@ function WeeklyCalendar() {
   const handleDrop = async (e, targetDay) => {
     e.preventDefault();
     setDragOverDay(null);
+    setIsUnscheduleDragOver(false);
     
     if (!draggedTask || !targetDay) return;
     
-    const originalDate = new Date(draggedTask.originalDay);
+    const originalDate = draggedTask.originalDueDate
+      ? new Date(draggedTask.originalDueDate)
+      : null;
     const targetDate = new Date(targetDay);
-    
-    const hours = originalDate.getHours();
-    const minutes = originalDate.getMinutes();
+
+    const hours = originalDate ? originalDate.getHours() : 9;
+    const minutes = originalDate ? originalDate.getMinutes() : 0;
     targetDate.setHours(hours, minutes, 0, 0);
     
-    if (targetDate.toDateString() === originalDate.toDateString()) {
+    if (originalDate && targetDate.toDateString() === originalDate.toDateString()) {
       setDraggedTask(null);
       return;
     }
@@ -70,9 +74,43 @@ function WeeklyCalendar() {
     setDraggedTask(null);
   };
 
+  const handleUnscheduleDragOver = (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setIsUnscheduleDragOver(true);
+  };
+
+  const handleUnscheduleDragLeave = () => {
+    setIsUnscheduleDragOver(false);
+  };
+
+  const handleUnscheduleDrop = async (e) => {
+    e.preventDefault();
+    setDragOverDay(null);
+    setIsUnscheduleDragOver(false);
+
+    if (!draggedTask) return;
+    if (!draggedTask.task?.due_date) {
+      setDraggedTask(null);
+      return;
+    }
+
+    try {
+      await updateTask(draggedTask.task.id, { due_date: null });
+      setMessage('Task unscheduled');
+      setTimeout(() => setMessage(''), 3000);
+      refresh();
+    } catch (err) {
+      console.error('Failed to unschedule task:', err);
+    }
+
+    setDraggedTask(null);
+  };
+
   const handleDragEnd = () => {
     setDraggedTask(null);
     setDragOverDay(null);
+    setIsUnscheduleDragOver(false);
   };
 
   const formatDayHeader = (date) => {
@@ -205,7 +243,7 @@ function WeeklyCalendar() {
                           className={`calendar-task ${task.is_completed ? 'completed' : ''} ${draggedTask?.task.id === task.id ? 'dragging' : ''}`}
                           style={{ borderLeftColor: task.course_color || '#4a90a4' }}
                           draggable={!task.is_completed}
-                          onDragStart={(e) => handleDragStart(e, task, day)}
+                          onDragStart={(e) => handleDragStart(e, task)}
                           onDragEnd={handleDragEnd}
                         >
                           <div className="task-time">{formatTime(task.due_date)}</div>
@@ -234,11 +272,19 @@ function WeeklyCalendar() {
         <aside className="calendar-side-column">
           <section className="focus-panel" aria-labelledby="weekly-side-tasks-title">
             <h2 id="weekly-side-tasks-title" className="focus-panel-title">
-              Top Tasks
+              Unscheduled Tasks
             </h2>
             <p className="focus-panel-hint">Drag these tasks over to a day to set a due date.</p>
+            <div
+              className={`unschedule-drop-zone ${isUnscheduleDragOver ? 'drag-over' : ''}`}
+              onDragOver={handleUnscheduleDragOver}
+              onDragLeave={handleUnscheduleDragLeave}
+              onDrop={handleUnscheduleDrop}
+            >
+              Drag here to remove a due date
+            </div>
             <MiniTaskList
-              tasks={Object.values(tasksByDay).flat()}
+              tasks={tasks.filter(task => !task.due_date)}
               limit={5}
               prioritize
               readOnly
@@ -246,6 +292,9 @@ function WeeklyCalendar() {
               emptyMessageKey="noTasks"
               className="focus-panel-inner-list"
               emptyClassName="focus-panel-empty"
+              draggable
+              onTaskDragStart={handleDragStart}
+              onTaskDragEnd={handleDragEnd}
             />
           </section>
         </aside>

--- a/frontend/src/pages/WeeklyCalendar.jsx
+++ b/frontend/src/pages/WeeklyCalendar.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useWeeklyTasks } from '../hooks';
 import { useLanguage } from '../hooks/useLanguage';
 import { updateTask } from '../api';
+import { MiniTaskList } from "../components";
 
 function WeeklyCalendar() {
   const { t } = useLanguage();
@@ -152,6 +153,8 @@ function WeeklyCalendar() {
           </button>
         </div>
       </div>
+
+      <MiniTaskList tasks={Object.values(tasksByDay).flat()} />
 
       <div className="week-info">
         <h2>{formatWeekRange()}</h2>

--- a/frontend/src/pages/WeeklyCalendar.jsx
+++ b/frontend/src/pages/WeeklyCalendar.jsx
@@ -285,7 +285,6 @@ function WeeklyCalendar() {
             </div>
             <MiniTaskList
               tasks={tasks.filter(task => !task.due_date)}
-              limit={5}
               prioritize
               readOnly
               density="compact"


### PR DESCRIPTION
In the Weekly and Monthly views, a new pane is added to the side displaying tasks without a due date. Dragging them over to a date assigns the due date; dragging it away removes the due date.

For cleanliness, this involved a refactoring of the mini task list on the dashboard into a reusable `MiniTaskList` component to use in the Weekly and Monthly views. 

**Before:**

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/d2f922e3-8237-460c-830c-dda51d094cff" />

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/6963b0cb-84b6-4efb-a96d-8f0f657b0465" />

---

**After:**

https://github.com/user-attachments/assets/c734433a-4116-46ad-859e-acf2e6938bcf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unschedule tasks by dragging them to a new "Unscheduled Tasks" side panel; shows a success message when unscheduled.
  * Compact task list component with optional prioritization, read-only mode, and draggable support.

* **UI/UX Improvements**
  * Visual drag-and-drop affordances, active-state styling (including dark-mode), and a responsive two-column calendar layout that collapses to one column on smaller screens; wider monthly view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->