### PR TITLE
Add Task button navigates user to Tasks page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Link, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { LanguageProvider, useLanguage, languages } from './hooks/useLanguage';
 import { NotificationBell, AIAssistant, FocusTimer } from './components';
@@ -80,6 +80,7 @@ function PrivateRoute({ children }) {
 }
 
 function NavBar({ onOpenFocusTimer }) {
+  const navigate = useNavigate();
   const { user, logout, showWelcome } = useAuth();
   const { t, language, setLanguage } = useLanguage();
   const [isDark, toggleDark] = useDarkMode();
@@ -125,6 +126,8 @@ function NavBar({ onOpenFocusTimer }) {
   };
 
   const handleAddTask = () => {
+    localStorage.setItem('openAddTask', 'true');
+    navigate('/tasks');
     localStorage.setItem('openAddTask', 'true');
     window.dispatchEvent(new Event('openAddTask'));
   };
@@ -264,6 +267,7 @@ function NavBar({ onOpenFocusTimer }) {
 function AppRoutes() {
   const { user, showWelcome } = useAuth();
   const { t } = useLanguage();
+  const location = useLocation();
   const [showAI, setShowAI] = useState(false);
   const [showFocusTimer, setShowFocusTimer] = useState(false);
 
@@ -274,6 +278,17 @@ function AppRoutes() {
     window.addEventListener('openChatbot', handleOpenChatbot);
     return () => window.removeEventListener('openChatbot', handleOpenChatbot);
   }, []);
+
+  useEffect(() => {
+    if (location.pathname === '/tasks' && localStorage.getItem('openAddTask') === 'true') {
+      const id = setTimeout(() => {
+        window.dispatchEvent(new Event('openAddTask'));
+        localStorage.removeItem('openAddTask');
+      }, 0);
+
+      return () => clearTimeout(id);
+    }
+  }, [location.pathname]);
 
   return (
     <>


### PR DESCRIPTION
**Behavior before:** Add Task button would open the task-adding pane *only if the user was on a page that supported that functionality.* So if a user was on the Weekly page, then the button did nothing...

https://github.com/user-attachments/assets/c23332fa-6f8f-447e-b527-6d8a4cc6e788

**Behavior now:** Add Task button first navigates the user to the Tasks page, then opens the task adding pane. So the button works on every page.

https://github.com/user-attachments/assets/fae863bf-a244-477a-94b8-d1b6253db03c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the add task flow to properly handle navigation within the application, ensuring the add task interface appears correctly when navigating to the tasks section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->