### PR TITLE
Make FocusTimer modal draggable

### DIFF
--- a/frontend/src/components/FocusTimer.css
+++ b/frontend/src/components/FocusTimer.css
@@ -12,6 +12,11 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 20px;
+  user-select: none;
+}
+
+.focus-timer-header:active {
+  cursor: grabbing;
 }
 
 .focus-timer-header h2 {

--- a/frontend/src/components/FocusTimer.jsx
+++ b/frontend/src/components/FocusTimer.jsx
@@ -14,6 +14,54 @@ function FocusTimer({ isOpen, onClose }) {
   const [showNotificationPermission, setShowNotificationPermission] = useState(false);
   const timerRef = useRef(null);
   const wasRunningRef = useRef(false);
+  const [modalPos, setModalPos] = useState({ x: 0, y: 0 });
+  const isDragging = useRef(false);
+  const dragStart = useRef({ mouseX: 0, mouseY: 0, posX: 0, posY: 0 });
+  const wasDragged = useRef(false);
+
+  useEffect(() => {
+    if (isOpen) setModalPos({ x: 0, y: 0 });
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      if (!isDragging.current) return;
+      wasDragged.current = true;
+      setModalPos({
+        x: dragStart.current.posX + e.clientX - dragStart.current.mouseX,
+        y: dragStart.current.posY + e.clientY - dragStart.current.mouseY,
+      });
+    };
+    const handleMouseUp = () => {
+      isDragging.current = false;
+    };
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, []);
+
+  const handleDragStart = (e) => {
+    isDragging.current = true;
+    wasDragged.current = false;
+    dragStart.current = {
+      mouseX: e.clientX,
+      mouseY: e.clientY,
+      posX: modalPos.x,
+      posY: modalPos.y,
+    };
+    e.preventDefault();
+  };
+
+  const handleOverlayClick = () => {
+    if (wasDragged.current) {
+      wasDragged.current = false;
+      return;
+    }
+    onClose();
+  };
 
   useEffect(() => {
     if (Notification.permission === 'default') {
@@ -116,11 +164,15 @@ function FocusTimer({ isOpen, onClose }) {
   const progress = ((duration * 60 - timeLeft) / (duration * 60)) * 100;
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="focus-timer-modal" onClick={e => e.stopPropagation()}>
-        <div className="focus-timer-header">
+    <div className="modal-overlay" onClick={handleOverlayClick}>
+      <div
+        className="focus-timer-modal"
+        onClick={e => e.stopPropagation()}
+        style={{ transform: `translate(${modalPos.x}px, ${modalPos.y}px)` }}
+      >
+        <div className="focus-timer-header" onMouseDown={handleDragStart} style={{ cursor: 'grab' }}>
           <h2>🎯 {t('focusMode')}</h2>
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose} style={{ cursor: 'pointer' }}>×</button>
         </div>
 
         {showNotificationPermission && (


### PR DESCRIPTION
## Summary
- The Focus Timer modal can now be dragged around the screen by its header
- Added a grab/grabbing cursor on the header and prevented accidental close on drag-release

## Test plan
- [ ] Open the Focus Timer modal and drag it by the header
- [ ] Verify clicking the overlay (without dragging) still closes the modal
- [ ] Verify the close button still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FocusTimer modal is now draggable. Drag the header to reposition the timer on your screen. The modal close function works only when you don't drag, preventing accidental closures during repositioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->